### PR TITLE
Reorganize data as files named from input content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /bin/scrape.sessions.json
+/cache/
 /data/questions/
 /dist/
 /docs/

--- a/bin/reorganize.py
+++ b/bin/reorganize.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+import hashlib
+import json
+import logging
+import os
+import pathlib
+
+import fire
+from sprig import dictutils
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = pathlib.Path(__file__).parents[1]
+
+
+def is_manual_example(name: str) -> bool:
+    return any(
+        [
+            name.startswith("example"),
+            name == "easy",
+        ]
+    )
+
+
+def main() -> None:
+    old_data_path = PROJECT_ROOT / "data.bak"
+    new_data_path = PROJECT_ROOT / "data"
+
+    old_inputs_path = old_data_path / "inputs"
+    old_answers_path = old_data_path / "answers.json"
+
+    new_inputs_path = new_data_path / old_inputs_path.name
+    new_answers_path = new_data_path / old_answers_path.name
+    old_data_path.mkdir()
+    new_inputs_path.rename(old_inputs_path)
+    new_answers_path.rename(old_answers_path)
+
+    answers = dictutils.deflate(json.loads((old_answers_path).read_text()))
+    inputs = {
+        path.relative_to(old_inputs_path).with_suffix("").__str__(): path.read_text()
+        for path in old_inputs_path.glob("*/*/*.txt")
+    }
+
+    for k, v in answers.items():
+        y, d, p, old_name = k.split("/")
+        if is_manual_example(old_name):
+            new_name = old_name.upper()
+        else:
+            new_name = hashlib.sha256(
+                inputs[f"{y:04}/{d:02}/{old_name}"].encode()
+            ).hexdigest()[:16]
+
+        new_path = new_data_path / f"{y:04}/{d:02}/answers/{p:01}/{new_name}.txt"
+        if new_path.exists():
+            logger.warning("Duplicate answer: %s", new_path)
+        new_path.parent.mkdir(parents=True, exist_ok=True)
+        new_path.write_text(v)
+
+    for k, v in sorted(inputs.items()):
+        y, d, old_name = k.split("/")
+        if is_manual_example(old_name):
+            new_name = old_name.upper()
+        else:
+            new_name = hashlib.sha256(v.encode()).hexdigest()[:16]
+
+        new_path = new_data_path / f"{y:04}/{d:02}/inputs/{new_name}.txt"
+        if new_path.exists():
+            logger.warning("Duplicate input: %s", new_path)
+        new_path.parent.mkdir(parents=True, exist_ok=True)
+        new_path.write_text(v)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=getattr(logging, os.environ.get("LEVEL", "WARNING")))
+    fire.Fire(main)

--- a/bin/scrape.py
+++ b/bin/scrape.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python3
 import datetime
-import functools
 import hashlib
 import itertools
 import json
 import logging
-import os
 import pathlib
+import random
 import re
 import time
-from typing import Optional
+from typing import Any, Optional
 
+import env_logger
 import fire
+import more_itertools
 import requests
-from sprig import dictutils
+from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 
@@ -22,86 +23,89 @@ class AnswerNotFoundError(Exception):
     ...
 
 
+def _hexdigest(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()[:16]
+
+
 class Session:
     def __init__(
         self,
         session: str,
-        cache_location: pathlib.Path = pathlib.Path(__file__).parents[1] / "data",
-        user_fingerprint: Optional[str] = None,
+        cache_location: pathlib.Path = pathlib.Path(__file__).parents[1] / "cache",
+        data_location: pathlib.Path = pathlib.Path(__file__).parents[1] / "data",
     ) -> None:
         self._cookie = session
-        self._answers = {}
         self._cache_location = cache_location
-        self._answers_location = cache_location / "answers.json"
+        self._data_location = data_location
         self._rate_limited_until = time.monotonic()
-        self._user_fingerprint = user_fingerprint
+        self.rng = random.Random(0)
 
-    def __enter__(self):
-        with self._answers_location.open() as f:
-            self._answers = dictutils.deflate(json.load(f))
+    @property
+    def index_location(self) -> pathlib.Path:
+        return self._cache_location / f"{self.user_id()}.json"
+
+    def __enter__(self) -> Self:
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        with self._answers_location.open("w") as f:
-            json.dump(dictutils.inflate(self._answers), f, sort_keys=True, indent=2)
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        pass
 
-    @functools.cache
-    def _get_text(self, url: str) -> str:
+    def _download(self, path: str, user_id: Optional[int], suffix: str) -> pathlib.Path:
+        if user_id is None:
+            preliminary: Optional[pathlib.Path] = None
+        else:
+            stem = path.replace("-", "--").replace("/", "-")
+            preliminary = (
+                self._cache_location / "user" / str(user_id) / stem
+            ).with_suffix(suffix)
+
+        if preliminary is not None and preliminary.exists():
+            logger.debug("Using cache for %s", preliminary)
+            return preliminary
+
         delay = max(0.0, self._rate_limited_until - time.monotonic())
-        logger.info("Downloading %s after %3.1f second delay", url, delay)
+        logger.info("Downloading %s after %3.1f second delay", path, delay)
         time.sleep(delay)
         resp = requests.get(
-            url,
+            "https://adventofcode.com/" + path,
             cookies={"session": self._cookie},
         )
         # Compromise between me being impatient and not wanting to hammer the server
-        self._rate_limited_until = time.monotonic() + 10
+        self._rate_limited_until = time.monotonic() + self.rng.gauss(10, 2)
         resp.raise_for_status()
-        return resp.text
+        content = resp.text
 
-    @functools.cache
-    def _input(self, year: int, day: int) -> str:
-        return self._get_text(f"https://adventofcode.com/{year}/day/{day}/input")
+        if preliminary is None:
+            stem = _hexdigest(content)
+            final = (self._cache_location / "other" / stem).with_suffix(suffix)
+        else:
+            final = preliminary
 
-    @functools.cache
-    def _question(self, year: int, day: int) -> str:
-        return self._get_text(f"https://adventofcode.com/{year}/day/{day}")
+        logger.debug("Populating cache for %s", final)
+        final.parent.mkdir(exist_ok=True, parents=True)
+        final.write_text(content)
+        return final
 
-    def user_fingerprint(self) -> str:
-        if self._user_fingerprint is None:
-            self._user_fingerprint = hashlib.sha1(
-                self._input(2020, 2).encode("ascii")
-            ).hexdigest()[:10]
-        return self._user_fingerprint
+    def input_path(self, year: int, day: int, stem: str) -> pathlib.Path:
+        return (
+            self._data_location / f"{year:04}" / f"{day:02}" / "inputs" / f"{stem}.txt"
+        )
 
     def input(self, year: int, day: int) -> str:
-        file_location = (
-            self._cache_location
-            / "inputs"
-            / f"{year:04}"
-            / f"{day:02}"
-            / f"{self.user_fingerprint()}.txt"
-        )
-        if not file_location.exists():
-            file_location.parent.mkdir(exist_ok=True, parents=True)
-            file_location.write_text(self._input(year, day))
-        return file_location.read_text()
+        cache_path = self._download(f"{year}/day/{day}/input", self.user_id(), ".txt")
+        content = cache_path.read_text()
+        stem = _hexdigest(content)
+        data_path = self.input_path(year, day, stem)
+        if data_path.exists():
+            logger.debug("Reusing input %s", data_path)
+        else:
+            logger.debug("Creating input %s", data_path)
+            data_path.parent.mkdir(parents=True, exist_ok=True)
+            data_path.write_text(content)
+        return data_path.read_text()
 
-    def question(self, year: int, day: int) -> str:
-        file_location = (
-            self._cache_location
-            / "questions"
-            / f"{year:04}"
-            / f"{day:02}"
-            / f"{self.user_fingerprint()}.html"
-        )
-        if not file_location.exists():
-            file_location.parent.mkdir(exist_ok=True, parents=True)
-            file_location.write_text(self._question(year, day))
-        return file_location.read_text()
-
-    def _answer(self, year: int, day: int, part: int) -> str:
-        question = self.question(year, day)
+    @staticmethod
+    def parsed_answer(question: str, part: int) -> str:
         answers = {
             i: m[1]
             for i, m in enumerate(
@@ -113,38 +117,61 @@ class Session:
         except KeyError as e:
             raise AnswerNotFoundError from e
 
-    def answer(self, year: int, day: int, part: int) -> str:
-        key = f"{year:04}/{day:02}/{part}/{self.user_fingerprint()}"
-        if key not in self._answers:
-            self._answers[key] = self._answer(year, day, part)
-        return self._answers[key]
-
-    def set_default_answers(self, year: int, day: int) -> None:
-        for part in [1, 2]:
-            keys = [
-                f"{year:04}/{day:02}/{part}/{self.user_fingerprint()}",
-                f"{year:04}/{day:02}/{part}/example",
-            ]
-            for key in keys:
-                if key not in self._answers:
-                    logger.debug("Creating default answer %s", key)
-                    self._answers.setdefault(key, "0")
-
-    def set_default_example(self, year: int, day: int) -> None:
-        file_location = (
-            self._cache_location
-            / "inputs"
+    def answer_path(self, year: int, day: int, part: int, stem: str) -> pathlib.Path:
+        return (
+            self._data_location
             / f"{year:04}"
             / f"{day:02}"
-            / f"example.txt"
+            / "answers"
+            / f"{part:1}"
+            / f"{stem}.txt"
         )
-        if not file_location.exists():
-            logger.debug("Creating default input %s", file_location)
-            file_location.touch()
+
+    def answer(self, year: int, day: int, part: int) -> str:
+        cache_path = self._download(f"{year}/day/{day}", self.user_id(), ".html")
+        content = cache_path.read_text()
+        stem = _hexdigest(self.input(year, day))
+        data_path = self.answer_path(year, day, part, stem)
+        if data_path.exists():
+            logger.debug("Reusing answer %s", data_path)
+        else:
+            logger.debug("Creating answer %s", data_path)
+            data_path.parent.mkdir(parents=True, exist_ok=True)
+            data_path.write_text(self.parsed_answer(content, part))
+        return content
+
+    @staticmethod
+    def parsed_user_id(page: str) -> int:
+        return int(
+            more_itertools.one(re.finditer(r"\(anonymous user #(\d+)\)", page))[1]
+        )
+
+    def user_id(self) -> int:
+        cache_path = self._download("settings", None, ".html")
+        content = cache_path.read_text()
+        return self.parsed_user_id(content)
+
+    def create_answer(self, year: int, day: int, part: int, stem: str) -> None:
+        path = self.answer_path(year, day, part, stem)
+        if path.exists():
+            logger.warning("Answer already exists %s", path)
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch()
+            logger.debug("Creating empty answer %s", path)
+
+    def create_input(self, year: int, day: int, stem: str, content: str = "") -> None:
+        path = self.input_path(year, day, stem)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.exists():
+            logger.warning("Input already exists %s", path)
+        else:
+            logger.debug("Creating empty input %s", path)
+            path.write_text(content)
 
 
 def _scrape_answers(session: Session) -> None:
-    logger.info(f"Scraping {session.user_fingerprint()} for answers")
+    logger.info(f"Scraping {session.user_id()} for answers")
     for year in itertools.count(2015):
         for day in range(1, 26):
             for part in [1, 2]:
@@ -160,7 +187,7 @@ def _scrape_answers(session: Session) -> None:
 
 
 def _scrape_inputs(session: Session) -> None:
-    logger.info(f"Scraping {session.user_fingerprint()} for inputs")
+    logger.info(f"Scraping {session.user_id()} for inputs")
     for year in itertools.count(2015):
         for day in range(1, 26):
             try:
@@ -172,20 +199,24 @@ def _scrape_inputs(session: Session) -> None:
 
 def _scrape_today(session: Session) -> None:
     now = datetime.datetime.now()
-    session.input(year=now.year, day=now.day)
-    session.set_default_answers(year=now.year, day=now.day)
-    session.set_default_example(year=now.year, day=now.day)
+    year, day = now.year, now.day
+
+    session.create_input(year, day, "EXAMPLE")
+    session.create_input(year, day, "INPUT", session.input(year, day))
+    for part in [1, 2]:
+        session.create_answer(year, day, part, "EXAMPLE")
+        session.create_answer(year, day, part, "INPUT")
 
 
 SAVED_COOKIES_PATH = pathlib.Path(__file__).with_suffix(".sessions.json")
 
 
-def _read_cookies() -> dict[str, str]:
+def _read_cookies() -> dict[int, str]:
     with SAVED_COOKIES_PATH.open() as f:
-        return json.load(f)
+        return {int(k): v for k, v in json.load(f).items()}
 
 
-def _write_cookies(cookies: dict[str, str]) -> None:
+def _write_cookies(cookies: dict[int, str]) -> None:
     with SAVED_COOKIES_PATH.open("w") as f:
         json.dump(cookies, f, indent=4, sort_keys=True)
 
@@ -198,29 +229,29 @@ class CLI:
         except FileNotFoundError:
             cookies = {}
         with Session(session_cookie) as session:
-            user_fingerprint = session.user_fingerprint()
-        cookies[user_fingerprint] = session_cookie
+            cookies[session.user_id()] = session_cookie
         _write_cookies(cookies)
 
     @staticmethod
     def scrape_answers() -> None:
         for fingerprint, cookie in _read_cookies().items():
-            with Session(session=cookie, user_fingerprint=fingerprint) as session:
+            with Session(session=cookie) as session:
                 _scrape_answers(session)
 
     @staticmethod
     def scrape_inputs() -> None:
         for fingerprint, cookie in _read_cookies().items():
-            with Session(session=cookie, user_fingerprint=fingerprint) as session:
+            with Session(session=cookie) as session:
                 _scrape_inputs(session)
 
     @staticmethod
     def today() -> None:
         for fingerprint, cookie in _read_cookies().items():
-            with Session(session=cookie, user_fingerprint=fingerprint) as session:
+            with Session(session=cookie) as session:
                 _scrape_today(session)
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=getattr(logging, os.environ.get("LEVEL", "WARNING")))
+    # logging.basicConfig(level=getattr(logging, os.environ.get("LEVEL", "WARNING")))
+    env_logger.configure()
     fire.Fire(CLI)

--- a/crates/aocoracle/src/aoclib.rs
+++ b/crates/aocoracle/src/aoclib.rs
@@ -376,7 +376,7 @@ mod tests {
     }
 
     #[test]
-    fn every_input_is_solved_by_exactly_one_solver() -> Result<(), AnyError> {
+    fn every_input_is_solved_by_exactly_one_solver() {
         let mut cols = BTreeMap::new();
         let mut num_correct = 0;
         let mut num_deletion = 0;
@@ -387,7 +387,7 @@ mod tests {
         let mut num_error = 0;
         let mut num_panic = 0;
         for (input_year, input_day, stem) in available_inputs() {
-            let input_key = || format!("{input_year}/{input_day:02}/{stem}");
+            let input_key = || format!("{input_year}/{input_day:02}/{stem:7}");
             let actual_answers = panic::catch_unwind(|| {
                 helper(
                     &Cli::new(None, None, None, true),
@@ -475,7 +475,7 @@ mod tests {
         dbg!(num_input);
         dbg!(num_solver);
         dbg!(num_pair);
-        println!("{}", as_ascii_table(&cols)?);
+        println!("{}", as_ascii_table(&cols).unwrap());
         println!(
             "word error rate: {}",
             (num_deletion + num_insertion + num_substitution) as f64
@@ -499,8 +499,7 @@ mod tests {
                 // Sanity check to see that every pair is counter once
                 num_pair,
             ),
-            (213, 0, 186, 4, 0, 2, num_input * num_solver),
+            (211, 0, 172, 4, 0, 2, num_input * num_solver),
         );
-        Ok(())
     }
 }

--- a/crates/aocoracle/src/testing.rs
+++ b/crates/aocoracle/src/testing.rs
@@ -1,11 +1,8 @@
 use crate::Part;
 use glob::glob;
 use std::any::type_name;
-use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::fs;
-
-type Answers = BTreeMap<u16, BTreeMap<u8, BTreeMap<Part, BTreeMap<String, String>>>>;
 
 fn year_day(file: &str) -> (u16, u8) {
     let re = regex::Regex::new(r"y(\d{4})/d(\d{2})").expect("Hard coded regex is valid");
@@ -17,7 +14,7 @@ fn year_day(file: &str) -> (u16, u8) {
 
 pub fn read_input(year: u16, day: u8, stem: &str) -> String {
     fs::read_to_string(format!(
-        "../../data/inputs/{:04}/{:02}/{}.txt",
+        "../../data/{:04}/{:02}/inputs/{}.txt",
         year, day, stem
     ))
     .unwrap()
@@ -25,12 +22,12 @@ pub fn read_input(year: u16, day: u8, stem: &str) -> String {
 
 pub fn available_inputs() -> Vec<(u16, u8, String)> {
     let mut result = Vec::new();
-    for entry in glob("../../data/inputs/*/*/*.txt").unwrap() {
+    for entry in glob("../../data/*/*/inputs/*.txt").unwrap() {
         let path = entry.unwrap();
         let stem = path.file_stem().unwrap().to_str().unwrap();
         let day = path
             .ancestors()
-            .nth(1)
+            .nth(2)
             .unwrap()
             .file_stem()
             .unwrap()
@@ -38,7 +35,7 @@ pub fn available_inputs() -> Vec<(u16, u8, String)> {
             .unwrap();
         let year = path
             .ancestors()
-            .nth(2)
+            .nth(3)
             .unwrap()
             .file_stem()
             .unwrap()
@@ -61,14 +58,11 @@ where
     func(&read_input(year, day, stem))
 }
 
-fn read_answers() -> Answers {
-    let text = &fs::read_to_string("../../data/answers.json").unwrap();
-    serde_json::from_str(text).unwrap()
-}
-
 pub fn expected_answer(year: u16, day: u8, part: Part, stem: &str) -> Option<String> {
-    let answers = read_answers();
-    Some(answers.get(&year)?.get(&day)?.get(&part)?.get(stem)?.into())
+    fs::read_to_string(format!(
+        "../../data/{year:04}/{day:02}/answers/{part:01}/{stem}.txt"
+    ))
+    .ok()
 }
 
 pub fn assert_correct_answer_on_correct_input_given_file<F, T, U>(

--- a/crates/aocoracle/src/y2018/d01.rs
+++ b/crates/aocoracle/src/y2018/d01.rs
@@ -43,22 +43,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "3ba7923eae", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "6802c3de5dea7df2", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "3ba7923eae", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "6802c3de5dea7df2", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2018/d02.rs
+++ b/crates/aocoracle/src/y2018/d02.rs
@@ -34,7 +34,7 @@ impl FromStr for Input {
         }
 
         if ids.len() < 2 {
-            // Avoid FP for 2015/04/3ba7923eae
+            // Avoid FP for 2015/04/42d4e25bdd6b87ef
             return Err(format!(
                 "Problem requires at least 2 ids to be solved but got {}",
                 ids.len()
@@ -102,25 +102,25 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "3ba7923eae", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "42d4e25bdd6b87ef", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example2() {
-        assert_correct_answer_on_correct_input!(part_2, "example2", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE2", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "3ba7923eae", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "42d4e25bdd6b87ef", Part::Two);
     }
 
-    #[ignore] // Cannot think of a way to invalidate 2015/05/3ba7923eae
+    #[ignore] // Cannot think of a way to invalidate 2015-05 3bf6e8b73a096b90
     #[test]
     fn returns_error_on_wrong_input() {
         assert_error_on_wrong_input!(part_1, part_2);

--- a/crates/aocoracle/src/y2018/d03.rs
+++ b/crates/aocoracle/src/y2018/d03.rs
@@ -86,22 +86,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "3ba7923eae", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "ff97aff3c8447359", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "3ba7923eae", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "ff97aff3c8447359", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2018/d04.rs
+++ b/crates/aocoracle/src/y2018/d04.rs
@@ -99,22 +99,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "3ba7923eae", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "772de2dba6be84e1", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "3ba7923eae", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "772de2dba6be84e1", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2018/d05.rs
+++ b/crates/aocoracle/src/y2018/d05.rs
@@ -64,22 +64,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "3ba7923eae", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "3660deebf52c30c8", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "3ba7923eae", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "3660deebf52c30c8", Part::Two);
     }
 
     //Fails on 2015/04/3ba7923eae

--- a/crates/aocoracle/src/y2018/d06.rs
+++ b/crates/aocoracle/src/y2018/d06.rs
@@ -167,22 +167,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "3ba7923eae", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "8b1268273d98c3e6", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(_part_2a, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(_part_2a, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2b, "3ba7923eae", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2b, "8b1268273d98c3e6", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2018/d07.rs
+++ b/crates/aocoracle/src/y2018/d07.rs
@@ -241,22 +241,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "3ba7923eae", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "8a463747b9895b96", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(_part_2a, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(_part_2a, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2b, "3ba7923eae", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2b, "8a463747b9895b96", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2018/d08.rs
+++ b/crates/aocoracle/src/y2018/d08.rs
@@ -97,22 +97,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "3ba7923eae", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "e2feb0983af51c38", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "3ba7923eae", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "e2feb0983af51c38", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2020/d01.rs
+++ b/crates/aocoracle/src/y2020/d01.rs
@@ -49,22 +49,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "e76707b9f6829f2f", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "e76707b9f6829f2f", Part::Two);
     }
 
     #[ignore]

--- a/crates/aocoracle/src/y2020/d02.rs
+++ b/crates/aocoracle/src/y2020/d02.rs
@@ -77,22 +77,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "6aa335f0a1070945", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "6aa335f0a1070945", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2021/d01.rs
+++ b/crates/aocoracle/src/y2021/d01.rs
@@ -48,22 +48,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "765bc2a161e7527e", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "765bc2a161e7527e", Part::Two);
     }
 
     #[ignore]

--- a/crates/aocoracle/src/y2021/d02.rs
+++ b/crates/aocoracle/src/y2021/d02.rs
@@ -97,22 +97,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "4da2ac0fa3802bca", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "4da2ac0fa3802bca", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2021/d03.rs
+++ b/crates/aocoracle/src/y2021/d03.rs
@@ -133,22 +133,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "106da7c832c9e3da", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "106da7c832c9e3da", Part::Two);
     }
 
     #[ignore]
@@ -159,11 +159,11 @@ mod tests {
 
     #[test]
     fn oxygen_works_on_example() {
-        assert_eq!(actual_answer(file!(), _oxygen_only, "example").unwrap(), 23);
+        assert_eq!(actual_answer(file!(), _oxygen_only, "EXAMPLE").unwrap(), 23);
     }
 
     #[test]
     fn carbon_works_on_example() {
-        assert_eq!(actual_answer(file!(), _carbon_only, "example").unwrap(), 10);
+        assert_eq!(actual_answer(file!(), _carbon_only, "EXAMPLE").unwrap(), 10);
     }
 }

--- a/crates/aocoracle/src/y2021/d04.rs
+++ b/crates/aocoracle/src/y2021/d04.rs
@@ -116,22 +116,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "71a5f426ae360cd8", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "71a5f426ae360cd8", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2021/d05.rs
+++ b/crates/aocoracle/src/y2021/d05.rs
@@ -149,22 +149,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "1d830238f0dcd50a", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "1d830238f0dcd50a", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2021/d06.rs
+++ b/crates/aocoracle/src/y2021/d06.rs
@@ -66,22 +66,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "609e548454f4e3c0", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "609e548454f4e3c0", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2021/d07.rs
+++ b/crates/aocoracle/src/y2021/d07.rs
@@ -79,22 +79,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "9041c4627e11f8b0", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "9041c4627e11f8b0", Part::Two);
     }
 
     #[ignore]

--- a/crates/aocoracle/src/y2021/d08.rs
+++ b/crates/aocoracle/src/y2021/d08.rs
@@ -128,22 +128,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "25a23fe8cab4150a", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "25a23fe8cab4150a", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2021/d20.rs
+++ b/crates/aocoracle/src/y2021/d20.rs
@@ -152,22 +152,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "78e746f978f86ca1", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "78e746f978f86ca1", Part::Two);
     }
 
     #[ignore]

--- a/crates/aocoracle/src/y2021/d21.rs
+++ b/crates/aocoracle/src/y2021/d21.rs
@@ -103,22 +103,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "da2f29b03f7891fc", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "da2f29b03f7891fc", Part::Two);
     }
 
     #[ignore]

--- a/crates/aocoracle/src/y2021/d22.rs
+++ b/crates/aocoracle/src/y2021/d22.rs
@@ -139,30 +139,30 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example_s() {
-        assert_correct_answer_on_correct_input!(part_1, "example_s", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE_S", Part::One);
     }
     #[test]
     fn part_1_works_on_example_m() {
-        assert_correct_answer_on_correct_input!(part_1, "example_m", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE_M", Part::One);
     }
     #[test]
     fn part_1_works_on_example_l() {
-        assert_correct_answer_on_correct_input!(part_1, "example_l", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE_L", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "bb449b26d369d484", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example_l() {
-        assert_correct_answer_on_correct_input!(part_2, "example_l", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE_L", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "bb449b26d369d484", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2021/d23.rs
+++ b/crates/aocoracle/src/y2021/d23.rs
@@ -411,22 +411,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "a91160452e896c38", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "a91160452e896c38", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2021/d24.rs
+++ b/crates/aocoracle/src/y2021/d24.rs
@@ -112,12 +112,12 @@ mod tests {
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "f45f137544db5bca", Part::One);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "f45f137544db5bca", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2021/d25.rs
+++ b/crates/aocoracle/src/y2021/d25.rs
@@ -111,12 +111,12 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "1a1a16638a95e9aa", Part::One);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2022/d01.rs
+++ b/crates/aocoracle/src/y2022/d01.rs
@@ -77,22 +77,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "fb18049b20d06f1c", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "fb18049b20d06f1c", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2022/d02.rs
+++ b/crates/aocoracle/src/y2022/d02.rs
@@ -138,22 +138,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "5edbf7131d1817c6", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "5edbf7131d1817c6", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2022/d03.rs
+++ b/crates/aocoracle/src/y2022/d03.rs
@@ -91,22 +91,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "0ab407c928b6ffa9", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "0ab407c928b6ffa9", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2022/d04.rs
+++ b/crates/aocoracle/src/y2022/d04.rs
@@ -62,22 +62,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "ecf39a26ddeb670e", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "ecf39a26ddeb670e", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2022/d05.rs
+++ b/crates/aocoracle/src/y2022/d05.rs
@@ -99,22 +99,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "8923c893118e604b", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "8923c893118e604b", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2022/d06.rs
+++ b/crates/aocoracle/src/y2022/d06.rs
@@ -43,22 +43,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "4b7d68c5eeb71eec", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "4b7d68c5eeb71eec", Part::Two);
     }
 
     // Fails on 2015/04/3ba7923eae and possibly others

--- a/crates/aocoracle/src/y2022/d07.rs
+++ b/crates/aocoracle/src/y2022/d07.rs
@@ -86,22 +86,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "dabac450f8d469a2", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "dabac450f8d469a2", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2022/d08.rs
+++ b/crates/aocoracle/src/y2022/d08.rs
@@ -194,22 +194,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "b9e43884cd00dcb7", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "b9e43884cd00dcb7", Part::Two);
     }
 
     // Fails on 2021/01 and possibly others

--- a/crates/aocoracle/src/y2022/d09.rs
+++ b/crates/aocoracle/src/y2022/d09.rs
@@ -110,27 +110,27 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "b83a17d7584b3d61", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_example_l() {
-        assert_correct_answer_on_correct_input!(part_2, "example_l", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE_L", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "b83a17d7584b3d61", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2022/d10.rs
+++ b/crates/aocoracle/src/y2022/d10.rs
@@ -242,22 +242,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "f3ebc778d81aafa4", Part::One);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "f3ebc778d81aafa4", Part::Two);
     }
 
     #[test]
-    fn part_2_works_on_3ba7923eae() {
-        assert_correct_answer_on_correct_input!(part_2, "3ba7923eae", Part::Two);
+    fn part_2_works_on_09475985b08b8984() {
+        assert_correct_answer_on_correct_input!(part_2, "09475985b08b8984", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2022/d11.rs
+++ b/crates/aocoracle/src/y2022/d11.rs
@@ -195,22 +195,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "4d41849c8478c59f", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "4d41849c8478c59f", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2022/d12.rs
+++ b/crates/aocoracle/src/y2022/d12.rs
@@ -99,22 +99,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "bbe19f54de6739e7", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "bbe19f54de6739e7", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2022/d13.rs
+++ b/crates/aocoracle/src/y2022/d13.rs
@@ -127,22 +127,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "cb26c4d83d6ff809", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "cb26c4d83d6ff809", Part::Two);
     }
 
     // Fails on 2021/18/3ba7923eae and possibly others

--- a/crates/aocoracle/src/y2022/d14.rs
+++ b/crates/aocoracle/src/y2022/d14.rs
@@ -215,22 +215,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "e9f04d40c5066aaa", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "e9f04d40c5066aaa", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2022/d15.rs
+++ b/crates/aocoracle/src/y2022/d15.rs
@@ -114,22 +114,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(_part_1a, "example", Part::One);
+        assert_correct_answer_on_correct_input!(_part_1a, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1b, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1b, "f95773a9a6b7f551", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(_part_2a, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(_part_2a, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2b, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2b, "f95773a9a6b7f551", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2022/d17.rs
+++ b/crates/aocoracle/src/y2022/d17.rs
@@ -217,22 +217,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "4a92cc03c1028b0c", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "4a92cc03c1028b0c", Part::Two);
     }
 
     #[test]
@@ -241,12 +241,12 @@ mod tests {
     }
 
     #[test]
-    fn part_1_works_on_3ba7923eae() {
-        assert_correct_answer_on_correct_input!(part_1, "3ba7923eae", Part::One);
+    fn part_1_works_on_76ed0dd5ed2dc0c8() {
+        assert_correct_answer_on_correct_input!(part_1, "76ed0dd5ed2dc0c8", Part::One);
     }
 
     #[test]
-    fn part_2_works_on_3ba7923eae() {
-        assert_correct_answer_on_correct_input!(part_2, "3ba7923eae", Part::Two);
+    fn part_2_works_on_76ed0dd5ed2dc0c8() {
+        assert_correct_answer_on_correct_input!(part_2, "76ed0dd5ed2dc0c8", Part::Two);
     }
 }

--- a/crates/aocoracle/src/y2022/d18.rs
+++ b/crates/aocoracle/src/y2022/d18.rs
@@ -152,22 +152,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "89fc896b3a0296e4", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "89fc896b3a0296e4", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2022/d20.rs
+++ b/crates/aocoracle/src/y2022/d20.rs
@@ -73,22 +73,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "6f67c62119a690c4", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "6f67c62119a690c4", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2022/d21.rs
+++ b/crates/aocoracle/src/y2022/d21.rs
@@ -154,22 +154,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "2a579015899426d7", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "2a579015899426d7", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2022/d23.rs
+++ b/crates/aocoracle/src/y2022/d23.rs
@@ -199,22 +199,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "e6adf19648853d59", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "e6adf19648853d59", Part::Two);
     }
 
     // Fails on 2015/18/3ba7923eae and possibly others

--- a/crates/aocoracle/src/y2022/d24.rs
+++ b/crates/aocoracle/src/y2022/d24.rs
@@ -397,22 +397,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "965994098166be30", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "965994098166be30", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2022/d25.rs
+++ b/crates/aocoracle/src/y2022/d25.rs
@@ -87,12 +87,12 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "0bda839c0a358db4", Part::One);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2023/d01.rs
+++ b/crates/aocoracle/src/y2023/d01.rs
@@ -92,22 +92,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "cdff074dd172ac1d", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example2", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE2", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "cdff074dd172ac1d", Part::Two);
     }
 
     #[test]

--- a/crates/aocoracle/src/y2023/d02.rs
+++ b/crates/aocoracle/src/y2023/d02.rs
@@ -108,22 +108,22 @@ mod tests {
 
     #[test]
     fn part_1_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_1, "example", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "EXAMPLE", Part::One);
     }
 
     #[test]
     fn part_1_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_1, "6bb0c0bd67", Part::One);
+        assert_correct_answer_on_correct_input!(part_1, "9db369b71386bf64", Part::One);
     }
 
     #[test]
     fn part_2_works_on_example() {
-        assert_correct_answer_on_correct_input!(part_2, "example", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "EXAMPLE", Part::Two);
     }
 
     #[test]
     fn part_2_works_on_input() {
-        assert_correct_answer_on_correct_input!(part_2, "6bb0c0bd67", Part::Two);
+        assert_correct_answer_on_correct_input!(part_2, "9db369b71386bf64", Part::Two);
     }
 
     #[test]


### PR DESCRIPTION
Storing them as individual files will avoid contention and merge conflicts in answers.json.

Naming them after the content will avoid bad conflicts of fingerprints; since every user does not get a unique input the fingerprint will not be unique either. Now, if two users who share input for the first problem don't share input for another problem the system with they will disagree on what the content of that file should be.

To accommodate the examples and other non-official inputs without creating an even deeper hierarchy the convention that official inputs have lower case names and other inputs have upper case names is established. This only works on case sensitive file systems, but the risk of collisions seems low enough that it should be viable everywhere.

Because naming files after the content makes the name unpredictable today's inputs and answers are also aliased as INPUT. When preparing a new module for the next days problem this name can be used to save some typing.

Because some inputs were the same for multiple users the total number of test inputs is lower after this change.